### PR TITLE
Update verification for callback file in WebView

### DIFF
--- a/library/src/main/java/com/wuadam/awesomewebview/AwesomeWebViewActivity.java
+++ b/library/src/main/java/com/wuadam/awesomewebview/AwesomeWebViewActivity.java
@@ -1377,7 +1377,7 @@ public class AwesomeWebViewActivity extends AppCompatActivity
                     if (null == filePickerFilePath) {
                         return;
                     }
-                    if (intent == null) {
+                    if (intent == null || (intent != null && intent.getDataString() == null)) {
                         if (filePickerCamMessage != null) {
                             results = new Uri[]{Uri.parse(filePickerCamMessage)};
                         }


### PR DESCRIPTION
## Problem
There was a problem when the user triggered the component of "Input File" through the webview, was not returning the file captured by the android camera

## Tested in OS Version
- [x] KitKat 4.4
- [x] Lollipop 5.0 - 5.11
- [x] Marshmallow 6.0 - 6.0.1
- [x] Nougat 7.0 - 7.1.2
- [x] Oreo 8.0 - 8.0.1
- [x] Pie 9.0

## references
#2